### PR TITLE
Added support for multiple repos in pr commit export tool

### DIFF
--- a/qualitas/static/css/style.css
+++ b/qualitas/static/css/style.css
@@ -1,1 +1,4 @@
 
+fieldset {
+    border-style: none;
+}

--- a/qualitas/templates/tools/pr_export.html
+++ b/qualitas/templates/tools/pr_export.html
@@ -5,71 +5,156 @@
 
 {% block content %}
 
-<div class="container">
-
-  <div class="row">
-    <div class="col s12">
-      <div class="card large">
-        <div class="card-content black-text">
-          <span class="card-title">Release PR Commit Exporter</span>
-          <div class="form-wrapper">
-            <form action="" method="POST" role="form">
-              {{ form.hidden_tag() }}
-
-              <!-- Repo Select Field -->
-              {% call render_field(form.repo) %}
-              {{ form.repo(id='repo-name') }}
-              {{ form.repo.label }}
-              {% endcall %}
-
-              <!-- Base Input Field -->
-              {% call render_field(form.base) %}
-              {{ form.base(id='commit-base') }}
-              {{ form.base.label }}
-              {% endcall %}
-
-              <!-- HEAD Input Field -->
-              {% call render_field(form.head) %}
-              {{ form.head(id='commit-head') }}
-              {{ form.head.label }}
-              {% endcall %}
-
-              <div class="row">
-                <footer class="col s12 form-footer">
-                  <p class="right-align">
-                    <button type="submit"
-                            class="btn btn-large waves-effect waves-light">Submit
-                    </button>
-                    <br/></p>
-                </footer>
-            </form>
+  <div class="container">
+    <div class="row">
+      <div class="col s12">
+        <div class="card">
+          <div class="card-content black-text">
+            <span class="card-title">Release PR Commit Exporter</span>
+            <div class="form-wrapper">
+              <form id="pr-form" action="" method="POST" role="form">
+                {{ form.hidden_tag() }}
+                <div id="fieldset-wrapper">
+                  <fieldset id="repo-fieldset" class="repo-fieldset">
+                    <div class="col s4">
+                    <!-- Repo Select Field -->
+                    {% call render_field(form.repo_1) %}
+                      <span>{{ form.repo_1.label }}</span>
+                      {{ form.repo_1(id='repo', class='browser-default') }}
+                    {% endcall %}
+                    </div>
+                    <div class="col s4">
+                      <!-- Base Input Field -->
+                      {% call render_field(form.base_1) %}
+                        {{ form.base_1(id='base') }}
+                        {{ form.base_1.label }}
+                      {% endcall %}
+                    </div>
+                    <div class="col s4">
+                      <!-- HEAD Input Field -->
+                      {% call render_field(form.head_1) %}
+                        {{ form.head_1(id='head') }}
+                        {{ form.head_1.label }}
+                      {% endcall %}
+                    </div>
+                  </fieldset>
+                </div>
+                <div class="row">
+                  <footer class="col s12 form-footer">
+                    <div class="row">
+                    <p class="left-align">
+                    <a class="btn-floating btn-large waves-effect waves-light red" onclick="clone()"><i class="material-icons">add</i></a>
+                    </p>
+                    </div>
+                    <p class="right-align">
+                      <button type="submit" class="btn btn-large waves-effect waves-light">Submit</button>
+                      <br/>
+                    </p>
+                  </footer>
+                </div>
+              </form>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
 {% endblock content %}
 
 {% block scripts %}
-{{ super() }}
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    let options = {};
-    let selectElems = document.querySelectorAll('select');
-    let selectInstances = M.FormSelect.init(selectElems, options);
+  {{ super() }}
+  <script>
+    let cloneIndex = $('.repo-fieldset').length;
 
-    // Post any error messages
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        {% for message in messages %}
-          M.toast({html: "{{ message }}"});
-        {% endfor %}
-      {% endif %}
+    function initForm() {
+      let selectOptions = {};
+      let fabOptions = {};
+      initFormSelect(selectOptions);
+      initFab(fabOptions);
+    }
+
+    function initFab(options) {
+      let elems = document.querySelectorAll('.fixed-action-btn');
+      M.FloatingActionButton.init(elems, options);
+    }
+
+    function initFormSelect(options) {
+      let selectElems = document.querySelectorAll('select');
+      M.FormSelect.init(selectElems, options);
+    }
+
+    function remove(el) {
+      $(el).remove();
+      cloneIndex--;
+      console.log('cloneIndex = ' + cloneIndex);
+    }
+
+    function genFieldIndex(str) {
+       let arr = str.split('_');
+       // Change the 1 to wherever the incremented value is in your id
+       arr[1] = cloneIndex;
+       // Smash it back together and return
+       return arr.join('_');
+    }
+
+    function clone() {
+
+      let fieldTypes = ['select', 'input'];
+      let $fieldset = $('#repo-fieldset').clone();
+      cloneIndex ++;
+      console.log('cloneIndex = ' + cloneIndex);
+
+      $fieldset.attr('id', genFieldIndex($fieldset.attr('id')));
+
+      for (let i = fieldTypes.length; i-- > 0;) {
+        let fields = $fieldset.find(fieldTypes[i]);
+        for (let f = fields.length; f-- > 0;) {
+          let $field = $(fields[f]);
+          // Increment the id and name according to cloneIndex
+          if ($field.attr('name')) {
+            $field.attr('id', genFieldIndex($field.attr('id')));
+            $field.attr('name', genFieldIndex($field.attr('name')));
+          }
+
+          // Clear value if it is an input field
+          if (fieldTypes[i] === 'input') {
+            $field.val('')
+          }
+
+        }
+      }
+
+      // Append a Remove button
+      let $button = $('<a></a>').addClass('btn-small')
+            .addClass('waves-effect')
+            .addClass('deep-orange')
+            .addClass('waves-light')
+            .addClass('right')
+            .text('Remove')
+            .click(function() {remove($fieldset)});
+
+      // Append Remove button to fieldset
+      $fieldset.append($button);
+
+      $('#fieldset-wrapper').append($fieldset);
+
+      return $fieldset
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+
+      initForm();
+
+      // Post any error messages
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          {% for message in messages %}
+            M.toast({html: "{{ message }}"});
+          {% endfor %}
+        {% endif %}
       {% endwith %}
-
-  });
-</script>
+    });
+  </script>
 
 {% endblock scripts %}

--- a/qualitas/tools/forms.py
+++ b/qualitas/tools/forms.py
@@ -25,6 +25,6 @@ TUTOR_REPOS = [
 
 
 class PullRequestExportForm(FlaskForm):
-    repo = SelectField('Repository', choices=[(x, x) for x in TUTOR_REPOS])
-    base = StringField('Base', [Length(min=7, max=40), DataRequired()])
-    head = StringField('Head', [Length(min=7, max=40), DataRequired()])
+    repo_1 = SelectField('Repository', choices=[(x, x) for x in TUTOR_REPOS])
+    base_1 = StringField('Base', validators=[Length(min=7, max=40), DataRequired()])
+    head_1 = StringField('Head', validators=[Length(min=7, max=40), DataRequired()])

--- a/qualitas/tools/views.py
+++ b/qualitas/tools/views.py
@@ -10,6 +10,7 @@ from qualitas.tools.forms import PullRequestExportForm
 from qualitas.lib.github_export import export
 from qualitas.utils import render_csv
 
+logging.basicConfig(level=logging.DEBUG)
 LOGS = logging.getLogger(__name__)
 
 tools = Blueprint('tools',
@@ -20,25 +21,51 @@ tools = Blueprint('tools',
 
 @tools.route('/pr-export', methods=['GET', 'POST'])
 def pull_request_export():
-    form = PullRequestExportForm(request.form)
-    if form.validate_on_submit():
-        LOGS.info('Pull Request Form validated correctly')
-        repo_name = form.repo.data
-        base = form.base.data
-        head = form.head.data
+    form = PullRequestExportForm()
 
-        pr_commits = export.get_pr_commit_data(repo_name, base, head)
+    if request.method == 'POST':
+        form_data = dict(request.form)
+        # Remove CSRF Token
+        form_data.pop('csrf_token')
+        LOGS.debug(form_data)
+
+        # Ensure the number of fields is a multiple of 3
+        if len(form_data) % 3 != 0:
+            flash('Incorrect number of entries per repository')
+            return redirect(url_for('tools.pull_request_export'))
+
+        LOGS.info('The POSTED form has the correct number of fields')
+
+        # Determine the number of repos
+        repo_num = int(len(form_data) / 3)
+
+        LOGS.info(f'Total Repos to check are {repo_num}')
+
+        pr_commits = []
+
+        for n in range(1, repo_num + 1):
+            repo_name = form_data[f'repo_{n}'][0]
+            base = form_data[f'base_{n}'][0]
+            head = form_data[f'head_{n}'][0]
+            LOGS.info(f'Currently processing {repo_name} b{base} h{head}')
+            commits = export.get_pr_commit_data(repo_name,
+                                                base,
+                                                head)
+            if commits:
+                pr_commits.extend(commits)
+            else:
+                LOGS.info(f'No PR Commits found for {repo_name}')
 
         if pr_commits:
             LOGS.info('There were pr {} commits found'.format(len(pr_commits)))
             fieldnames = pr_commits[0].keys()
 
             return render_csv(
-                fieldnames, pr_commits, '{}-{}-{}'.format(repo_name.split('/')[1], base, head))
+                fieldnames, pr_commits, 'pr-commits')
         else:
             LOGS.info('Something went wrong or no results were found')
             flash('There was a problem trying to find pull request commits. '
-                  'Ensure you selected the proper repository')
+                  'Ensure you filled out all fields correctly')
             return redirect(url_for('tools.pull_request_export'))
 
     return render_template('pr_export.html', form=form)


### PR DESCRIPTION
* renamed fields on PullRequestExportForm to allow for cloning.
* took the common fields for a PR lookup and made them into a fieldset
* added clone functionality to the pr-export form fields to allow support for many repositories.
* added remove button so that fields could be removed.
* changed layout of the form so fields sat on one line.
* updated view so that it could support 1 or more repos.
* added fieldset border-style to none in style.css