### PR TITLE
Added a way to view data in PR Export Tool

### DIFF
--- a/qualitas/templates/dashboards/base.html
+++ b/qualitas/templates/dashboards/base.html
@@ -1,0 +1,8 @@
+{% extends 'layouts/base.html' %}
+
+
+{% block styles %}
+  {{ super() }}
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css">
+{% endblock styles %}
+

--- a/qualitas/templates/dashboards/base.html
+++ b/qualitas/templates/dashboards/base.html
@@ -1,6 +1,5 @@
 {% extends 'layouts/base.html' %}
 
-
 {% block styles %}
   {{ super() }}
   <link rel="stylesheet" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css">

--- a/qualitas/templates/tools/pr_export.html
+++ b/qualitas/templates/tools/pr_export.html
@@ -1,4 +1,4 @@
-{% extends 'layouts/base.html' %}
+{% extends 'tools/base.html' %}
 {%- from '_helpers.html' import render_field %}
 
 {% block title %}Qualitas | PR Commit Exporter{% endblock title %}
@@ -47,7 +47,8 @@
                     </p>
                     </div>
                     <p class="right-align">
-                      <button type="submit" class="btn btn-large waves-effect waves-light">Submit</button>
+                      <button class="btn btn-large waves-effect waves-light" onclick="exportDataSubmit()">Export CSV</button>
+                      <button class="btn btn-large waves-effect waves-light blue" onclick="viewDataSubmit()">View Data</button>
                       <br/>
                     </p>
                   </footer>
@@ -140,6 +141,17 @@
       $('#fieldset-wrapper').append($fieldset);
 
       return $fieldset
+    }
+
+    function viewDataSubmit(e) {
+      let $view_data = $('#view_data');
+      $view_data.val('on');
+    }
+
+    function exportDataSubmit(e) {
+      e.preventDefault();
+      let $view_data = $('#view_data');
+      $view_data.val('off');
     }
 
     document.addEventListener('DOMContentLoaded', function () {

--- a/qualitas/templates/tools/pr_export.html
+++ b/qualitas/templates/tools/pr_export.html
@@ -143,13 +143,12 @@
       return $fieldset
     }
 
-    function viewDataSubmit(e) {
+    function viewDataSubmit() {
       let $view_data = $('#view_data');
       $view_data.val('on');
     }
 
-    function exportDataSubmit(e) {
-      e.preventDefault();
+    function exportDataSubmit() {
       let $view_data = $('#view_data');
       $view_data.val('off');
     }

--- a/qualitas/templates/tools/pr_export_view.html
+++ b/qualitas/templates/tools/pr_export_view.html
@@ -43,7 +43,6 @@
 
 {% endblock content %}
 
-
 {% block scripts %}
   {{ super() }}
   <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>

--- a/qualitas/templates/tools/pr_export_view.html
+++ b/qualitas/templates/tools/pr_export_view.html
@@ -8,30 +8,22 @@
       <div class="col s12">
       <h2>Pull Request Data</h2>
         <div class="repo-table-wrapper">
-          <table id="repo-table">
+          <table id="repo-table" class="cell-border">
               <thead>
               <tr>
                 <th>Repository</th>
                 <th>PR ID</th>
                 <th>Commit Message</th>
                 <th>Commit SHA</th>
-                <th>Commit Link</th>
-                <th>Commit Link (short)</th>
-                <th>PR Link</th>
-                <th>Text</th>
               </tr>
               </thead>
               <tbody>
                 {% for commit in pr_commits %}
                   <tr>
                     <td>{{ commit.repository }}</td>
-                    <td>{{ commit.pr_id }}</td>
+                    <td><a href="{{ commit.pr_link }}">{{ commit.pr_id }}</a></td>
                     <td>{{ commit.commit_message }}</td>
-                    <td>{{ commit.commit_sha }}</td>
-                    <td>{{ commit.commit_link }}</td>
-                    <td>{{ commit.cl_trimmed }}</td>
-                    <td>{{ commit.pr_link }}</td>
-                    <td>{{ commit.text }}</td>
+                    <td><a href="{{ commit.commit_link }}">{{ commit.commit_sha[:7] }}</a></td>
                   </tr>
                 {% endfor %}
               </tbody>
@@ -53,9 +45,14 @@
           "pageLength": 20,
           "columnDefs": [
             {
-              className: "dt-left"
+              "targets": 2,
+              "className": "dt-left",
+              "render": function(data, type, row) {
+                return data.replace(/(?:\r\n|\r|\n)/g, "<br>");
+              }
+
             }
-          ]
+          ],
         }
         );
     } );

--- a/qualitas/templates/tools/pr_export_view.html
+++ b/qualitas/templates/tools/pr_export_view.html
@@ -6,26 +6,32 @@
 
     <div class="row">
       <div class="col s12">
-      <h2>Tutor Repository Data</h2>
+      <h2>Pull Request Data</h2>
         <div class="repo-table-wrapper">
           <table id="repo-table">
               <thead>
               <tr>
                 <th>Repository</th>
-                <th>Open Issues</th>
-                <th>PRs</th>
-                <th>Latest GitHub Tag</th>
-                <th>Latest Commit</th>
+                <th>PR ID</th>
+                <th>Commit Message</th>
+                <th>Commit SHA</th>
+                <th>Commit Link</th>
+                <th>Commit Link (short)</th>
+                <th>PR Link</th>
+                <th>Text</th>
               </tr>
               </thead>
               <tbody>
-                {% for repo in repositories %}
+                {% for commit in pr_commits %}
                   <tr>
-                    <td><a href="{{ repo.repo_url }}" target="_blank">{{ repo.repo_name }}</a></td>
-                    <td><a href="{{ repo.issues_url }}" target="_blank">{{ repo.open_issues_count }}</a></td>
-                    <td><a href="{{ repo.pull_request_url }}" target="_blank">{{ repo.open_pull_requests_count }}</a></td>
-                    <td><a href="{{ repo.tags_url }}" target="_blank">{{ repo.latest_tag }}</a></td>
-                    <td><a href="{{ repo.commit_url }}" target="_blank">{{ repo.latest_commit_sha[:7] }}</a></td>
+                    <td>{{ commit.repository }}</td>
+                    <td>{{ commit.pr_id }}</td>
+                    <td>{{ commit.commit_message }}</td>
+                    <td>{{ commit.commit_sha }}</td>
+                    <td>{{ commit.commit_link }}</td>
+                    <td>{{ commit.cl_trimmed }}</td>
+                    <td>{{ commit.pr_link }}</td>
+                    <td>{{ commit.text }}</td>
                   </tr>
                 {% endfor %}
               </tbody>
@@ -36,6 +42,7 @@
   </div>
 
 {% endblock content %}
+
 
 {% block scripts %}
   {{ super() }}

--- a/qualitas/tools/forms.py
+++ b/qualitas/tools/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 
-from wtforms import SelectField, StringField, validators
+from wtforms import SelectField, StringField, HiddenField
 from wtforms.validators import DataRequired, Length
 
 from qualitas.admin.data import get_tutor_repos, CNX_HOSTS
@@ -12,6 +12,7 @@ class PullRequestExportForm(FlaskForm):
     repo_1 = SelectField('Repository', choices=[(x, x) for x in TUTOR_REPOS])
     base_1 = StringField('Base', validators=[Length(min=7, max=40), DataRequired()])
     head_1 = StringField('Head', validators=[Length(min=7, max=40), DataRequired()])
+    view_data = HiddenField(default='off')
 
 
 class ServerDiffForm(FlaskForm):

--- a/qualitas/tools/views.py
+++ b/qualitas/tools/views.py
@@ -34,18 +34,23 @@ def pull_request_export():
         LOGS.debug(form_data)
 
         # Ensure the number of fields is a multiple of 3
-        if len(form_data) % 3 != 0:
+        if len(form_data) % 4 != 0:
             flash('Incorrect number of entries per repository')
             return redirect(url_for('tools.pull_request_export'))
 
         LOGS.info('The POSTED form has the correct number of fields')
 
         # Determine the number of repos
-        repo_num = int(len(form_data) / 3)
+        repo_num = int(len(form_data) / 4)
 
         LOGS.info(f'Total Repos to check are {repo_num}')
 
         pr_commits = []
+
+        view_data = False
+
+        if form.data["view_data"] == "on":
+            view_data = True
 
         for n in range(1, repo_num + 1):
             repo_name = form_data[f'repo_{n}'][0]
@@ -61,12 +66,14 @@ def pull_request_export():
             else:
                 LOGS.info(f'No PR Commits found for {repo_name}')
 
-        if pr_commits:
+        if pr_commits and not view_data:
             LOGS.info('There were pr {} commits found'.format(len(pr_commits)))
             fieldnames = pr_commits[0].keys()
 
             return render_csv(
                 fieldnames, pr_commits, 'pr-commits')
+        elif pr_commits and view_data:
+            return render_template('pr_export_view.html', pr_commits=pr_commits)
         else:
             LOGS.info('Something went wrong or no results were found')
             flash('There was a problem trying to find pull request commits. '

--- a/qualitas/tools/views.py
+++ b/qualitas/tools/views.py
@@ -47,10 +47,7 @@ def pull_request_export():
 
         pr_commits = []
 
-        view_data = False
-
-        if form.data["view_data"] == "on":
-            view_data = True
+        view_data = form.data["view_data"] == "on"
 
         for n in range(1, repo_num + 1):
             repo_name = form_data[f'repo_{n}'][0]

--- a/qualitas/tools/views.py
+++ b/qualitas/tools/views.py
@@ -72,7 +72,7 @@ def pull_request_export():
         elif pr_commits and view_data:
             return render_template('pr_export_view.html', pr_commits=pr_commits)
         else:
-            LOGS.info('Something went wrong or no results were found')
+            LOGS.warning('Something went wrong or no results were found')
             flash('There was a problem trying to find pull request commits. '
                   'Ensure you filled out all fields correctly')
             return redirect(url_for('tools.pull_request_export'))


### PR DESCRIPTION
* Added a hidden field that is used to determine which button is clicked. Either Export CSV or View Data
* Updated templates to use their main directory base.html file instead of layouts/base.html
* Added button to the PR Export tool that sets "on" for the hidden field which is used in the view
* Created two javascript functions that appropriately set "on" or "off" to the view_data input
* Added template for viewing data and set up the html table.
* Update pr export view to use `view_data` to either render_template or render_csv.
* Update pr export view to account for new form item by using modulo 4 instead of 3.