### PR TITLE
Fix short repo name

### DIFF
--- a/qualitas/ext/flask_github/client.py
+++ b/qualitas/ext/flask_github/client.py
@@ -30,7 +30,7 @@ class GitHubClient(GitHub):
 
         for commit in comparison.commits:
             # Use our commit object
-            commit = Commit(commit._json_data, repo_name)
+            commit = Commit(commit._json_data, repo.full_name)
             LOGS.info(f'Checking commit {commit.sha}')
 
             if commit.is_pr_commit:

--- a/tests/integration/data/pr_export.json
+++ b/tests/integration/data/pr_export.json
@@ -1,24 +1,24 @@
 [
   {
-    "repository": "biglearn-api",
+    "repository": "openstax/biglearn-api",
     "commit_message": "Merge pull request #51 from openstax/faster_metadatas\n\nAdded metadata sequence numbers to course and ecosystem metadatas",
     "commit_sha": "cb5fc8e77d4ecc3787905e9c124fbb3b1c7e203f",
     "commit_link": "https://github.com/openstax/biglearn-api/commit/cb5fc8e77d4ecc3787905e9c124fbb3b1c7e203f",
     "cl_trimmed": "https://github.com/openstax/biglearn-api/commit/cb5fc8e",
     "pr_id": "51",
-    "pr_link": "https://github.com/biglearn-api/pull/51",
-    "text": "Added metadata sequence numbers to course and ecos [PR 51](https://github.com/openstax/biglearn-api/commit/cb5fc8e)[cb5fc8e](https://github.com/biglearn-api/pull/51)",
+    "pr_link": "https://github.com/openstax/biglearn-api/pull/51",
+    "text": "Added metadata sequence numbers to course and ecos [PR 51](https://github.com/openstax/biglearn-api/commit/cb5fc8e)[cb5fc8e](https://github.com/openstax/biglearn-api/pull/51)",
     "milestone": "Release 2018-12-04; Code Freeze 2018-11-26"
   },
   {
-    "repository": "biglearn-api",
+    "repository": "openstax/biglearn-api",
     "commit_message": "Merge pull request #78 from openstax/speed_up_event_query\n\nSpeed up the event queries",
     "commit_sha": "3c0fdb4ad15127d0d3eac2ff9ba376f94bf4c24f",
     "commit_link": "https://github.com/openstax/biglearn-api/commit/3c0fdb4ad15127d0d3eac2ff9ba376f94bf4c24f",
     "cl_trimmed": "https://github.com/openstax/biglearn-api/commit/3c0fdb4",
     "pr_id": "78",
-    "pr_link": "https://github.com/biglearn-api/pull/78",
-    "text": "Speed up the event queries [PR 78](https://github.com/openstax/biglearn-api/commit/3c0fdb4)[3c0fdb4](https://github.com/biglearn-api/pull/78)",
+    "pr_link": "https://github.com/openstax/biglearn-api/pull/78",
+    "text": "Speed up the event queries [PR 78](https://github.com/openstax/biglearn-api/commit/3c0fdb4)[3c0fdb4](https://github.com/openstax/biglearn-api/pull/78)",
     "milestone": "Release 2018-12-04; Code Freeze 2018-11-26"
   }
 ]


### PR DESCRIPTION
The short repo name was being used which made the PR link incorrect. The full_repo_name is now being used and the integration test has been updated.