### PR TITLE
Remove register_blueprint function and register them manually

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean clean-test clean-pyc clean-build docs help
 .DEFAULT_GOAL := help
 
-DB := qualitas_db
+DB_NAME ?= qualitas_db
 
 clean: clean-build clean-pyc clean-test
 
@@ -24,8 +24,8 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 initdb:
-	docker-compose exec db psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS ${DB}"
-	docker-compose exec db psql -h db -d postgres -U postgres -c "CREATE DATABASE ${DB} ENCODING 'UTF8'"
+	docker-compose exec db psql -h db -d postgres -U postgres -c "DROP DATABASE IF EXISTS ${DB_NAME}"
+	docker-compose exec db psql -h db -d postgres -U postgres -c "CREATE DATABASE ${DB_NAME} ENCODING 'UTF8'"
 	docker-compose exec web alembic upgrade head
 
 venv:

--- a/qualitas/auth/views.py
+++ b/qualitas/auth/views.py
@@ -18,7 +18,6 @@ from ..core import db
 
 auth = Blueprint('auth',
                  __name__,
-                 url_prefix='/auth',
                  template_folder='../templates/auth')
 
 

--- a/qualitas/dashboards/views.py
+++ b/qualitas/dashboards/views.py
@@ -7,7 +7,6 @@ from qualitas.dashboards.logic import get_repository_dashboard_data
 
 dashboards = Blueprint('dashboards',
                        __name__,
-                       url_prefix='/dashboards',
                        template_folder='../templates/dashboards')
 
 TUTOR_REPOS = data.get_tutor_repos()

--- a/qualitas/ext/flask_zenhub/base.py
+++ b/qualitas/ext/flask_zenhub/base.py
@@ -6,7 +6,7 @@ class ZenHub(object):
 
     def __init__(self, app=None, client_class=ZenHubClient):
         self.app = app
-        self.client = client_class
+        self._client = client_class
         self.token = None
 
         if app is not None:
@@ -17,11 +17,11 @@ class ZenHub(object):
         app.zenhub = self
         app.extensions['zenhub'] = self
 
-        app.config.setdefault('ZENHUB_TOKEN')
+        app.config.setdefault('ZENHUB_TOKEN', None)
 
         self.token = app.config['ZENHUB_TOKEN']
 
         self.client = self.init_client()
 
     def init_client(self):
-        return self.client(token=self.token)
+        return self._client(token=self.token)

--- a/qualitas/factory.py
+++ b/qualitas/factory.py
@@ -2,15 +2,20 @@ from flask import Flask
 from flask_security import SQLAlchemyUserDatastore
 
 from .auth.models import User, Role
+from .auth.views import auth
 from .core import (babel,
                    db,
                    github,
                    security,
                    zenhub)
+from .dashboards.views import dashboards
 from .ext.markdown import Markdown, markdown
+from .home.views import home
+from .tools.views import tools
 from .utils import (register_blueprints,
                     WikiTitleConverter,
                     SlugConverter)
+from .wiki.views import wiki
 
 
 def create_app(package_name, package_path, settings=None):
@@ -65,8 +70,11 @@ def create_app(package_name, package_path, settings=None):
     app.url_map.converters['wiki_title'] = WikiTitleConverter
     app.url_map.converters['slug'] = SlugConverter
 
-    # Helper for auto-registering blueprints
-    # http://flask.pocoo.org/docs/1.0/blueprints/
-    register_blueprints(app, package_name, package_path)
+    # Register blueprints
+    app.register_blueprint(home, url_prefix="/")
+    app.register_blueprint(auth, url_prefix="/auth")
+    app.register_blueprint(dashboards, url_prefix="/dashboards")
+    app.register_blueprint(tools, url_prefix="/tools")
+    app.register_blueprint(wiki, url_prefix="/wiki")
 
     return app

--- a/qualitas/templates/dashboards/cnx_repos.html
+++ b/qualitas/templates/dashboards/cnx_repos.html
@@ -3,7 +3,7 @@
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <title>CNX Repos Dashboard</title>
+  <title>Qualitas | CNX Repos Dashboard</title>
 
   <meta name="viewport" content="width=700">
   <link rel="shortcut icon" href="{{ url_for('static', filename='ico/newspaper.ico') }}" type="image/x-icon">

--- a/qualitas/templates/dashboards/tutor_repos.html
+++ b/qualitas/templates/dashboards/tutor_repos.html
@@ -1,5 +1,7 @@
 {% extends 'dashboards/base.html' %}
 
+{% block title %}Qualitas | Tutor Repository Dashboard{% endblock title %}
+
 {% block content %}
 
   <div class="container">

--- a/qualitas/templates/dashboards/urlcommands.html
+++ b/qualitas/templates/dashboards/urlcommands.html
@@ -5,7 +5,7 @@
   <link rel="shortcut icon" href="{{ url_for('static', filename='ico/rotary.ico') }}" type="image/x-icon">
   <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/urlcommands.css') }}">
   <script type="text/javascript" src="{{ url_for('static', filename='js/urlcommands/urlcommands.js') }}"></script>
-  <title>URL Commands Dashboard - OpenStax Content Team</title>
+  <title>Qualitas | URL Commands Dashboard</title>
 </head>
 <body>
   <h1 class="title">URL Commands Dashboard</h1>

--- a/qualitas/templates/tools/history_diff.html
+++ b/qualitas/templates/tools/history_diff.html
@@ -2,7 +2,7 @@
 {%- from '_helpers.html' import render_field %}
 {% set ace_editor = True %}
 
-{% block title %}Server Diff Tool | Qualitas{% endblock title %}
+{% block title %}Qualitas | Server Diff Tool{% endblock title %}
 
 {% block content %}
   <div class="container page">

--- a/qualitas/templates/wiki/index.html
+++ b/qualitas/templates/wiki/index.html
@@ -1,6 +1,6 @@
 {% extends 'wiki/base.html' %}
 
-{% block title %}Wiki Pages | Qualitas{% endblock title %}
+{% block title %}Qualitas | Wiki Pages{% endblock title %}
 
 {% block content %}
 

--- a/qualitas/tools/views.py
+++ b/qualitas/tools/views.py
@@ -19,7 +19,6 @@ LOGS = logging.getLogger(__name__)
 
 tools = Blueprint('tools',
                   __name__,
-                  url_prefix='/tools',
                   template_folder='../templates/tools')
 
 

--- a/qualitas/wiki/views.py
+++ b/qualitas/wiki/views.py
@@ -17,7 +17,6 @@ LOGS = logging.getLogger(__name__)
 
 wiki = Blueprint('wiki',
                  __name__,
-                 url_prefix='/wiki',
                  template_folder='../templates/wiki')
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,7 @@ pytest-cov==2.6.1
 python-dateutil==2.7.3
 python-dotenv==0.9.1
 python-editor==1.0.4
+pytest-postgresql==1.4.0
 pytz==2018.5
 redis==2.10.6
 requests==2.20.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,6 @@ description-file = README.md
 [tool:pytest]
 addopts= -vvv --tb=long --showlocals tests/
 norecursedirs = build docs/_build *.egg .tox *.venv /home/travis/virtualenv
-postgresql_host = 127.0.0.1
+postgresql_host = db
 postgresql_port = 5432
 postgresql_user = postgres

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 import os
 
 import pytest
+from alembic.command import upgrade
+from alembic.config import Config as AlembicConfig
+
+from pytest_postgresql.factories import (init_postgresql_database,
+                                         drop_postgresql_database,
+                                         get_config)
 from webtest import TestApp
 
 from qualitas import create_app
@@ -14,16 +20,45 @@ credentials = [
 
 
 @pytest.fixture(scope='session')
-def app_config():
+def config_database(request):
+    connection_string = 'postgresql+psycopg2://{0}@{1}:{2}/{3}'
+
+    config = get_config(request)
+    pg_host = config.get('host')
+    pg_port = config.get('port', 5432)
+    pg_user = config.get('user')
+    pg_db = config.get('db', 'tests')
+
+    # Create the database
+    init_postgresql_database(pg_user, pg_host, pg_port, pg_db)
+
+    yield connection_string.format(pg_user, pg_host, pg_port, pg_db)
+
+    # Ensure the database gets deleted
+    drop_postgresql_database(
+        pg_user, pg_host, pg_port, pg_db, '10.5'
+    )
+
+
+@pytest.fixture(scope='session')
+def app_config(config_database):
     """The config for the test application"""
     settings = {
         'TESTING': True,
         'SECRET_KEY': 'a key for testing',
         'DEBUG': True,
+        'SQLALCHEMY_DATABASE_URI': config_database,
+        'WTF_CSRF_ENABLED': False,
         'GITHUB_USER': credentials[0],
         'GITHUB_PASSWORD': credentials[1],
         'ZENHUB_TOKEN': credentials[2]
     }
+
+    # Run Database migrations
+    config = AlembicConfig('alembic.ini')
+    config.set_main_option('sqlalchemy.url', config_database)
+    print('\n----- RUN ALEMBIC MIGRATION -----\n')
+    upgrade(config, 'head')
 
     return settings
 

--- a/tests/integration/test_dashboards.py
+++ b/tests/integration/test_dashboards.py
@@ -1,0 +1,8 @@
+def test_get_cnx_repos_view(test_client):
+    response = test_client.get("/dashboards/cnx-repos")
+    assert "<title>Qualitas | CNX Repos Dashboard</title>" in response
+
+
+def test_get_url_commands_view(test_client):
+    response = test_client.get("/dashboards/urlcommands")
+    assert "<title>Qualitas | URL Commands Dashboard</title>" in response

--- a/tests/integration/test_home.py
+++ b/tests/integration/test_home.py
@@ -1,0 +1,3 @@
+def test_get_home_view(test_client):
+    response = test_client.get("/")
+    assert "<title>Qualitas | Home</title>" in response

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -1,0 +1,8 @@
+def test_get_merge_pr_view_has_title(test_client):
+    response = test_client.get("/tools/pr-export")
+    assert "<title>Qualitas | PR Commit Exporter</title>" in response
+
+
+def test_get_history_view_has_title(test_client):
+    response = test_client.get("/tools/history-diff")
+    assert "<title>Qualitas | Server Diff Tool</title>" in response

--- a/tests/integration/test_wiki.py
+++ b/tests/integration/test_wiki.py
@@ -1,0 +1,3 @@
+def test_get_wiki_index_title(test_client):
+    response = test_client.get("/wiki/")
+    assert "<title>Qualitas | Wiki Pages</title>" in response

--- a/travis-compose.yml
+++ b/travis-compose.yml
@@ -3,7 +3,6 @@ services:
   web:
     build: ./
     environment:
-      - DATABASE_URL=postgres://postgres:@db/testing
       - FLASK_APP=wsgi.py
       - FLASK_DEBUG=1
       - FLASK_ENV=development

--- a/travis-compose.yml
+++ b/travis-compose.yml
@@ -17,4 +17,4 @@ services:
   db:
     image: postgres:10.5-alpine
     ports:
-      - '127.0.0.1:5433:5432'
+      - '127.0.0.1:5432:5432'

--- a/travis-compose.yml
+++ b/travis-compose.yml
@@ -9,6 +9,8 @@ services:
       - GITHUB_USER=${GITHUB_USER}
       - GITHUB_PASSWORD=${GITHUB_PASSWORD}
       - ZENHUB_TOKEN=${ZENHUB_TOKEN}
+      - DB_HOST=${DB_HOST}
+      - DB_NAME=${DB_NAME}
     ports:
       - "5000:5000"
     links:


### PR DESCRIPTION
A register_bluebrint utility was used to register blueprints. I believe
this made things easy but harder to understand as far as what routes
existed on the app. Blueprints are now registered one by one and easy to
glance in one place.

* Rename internal client name on ZenHub client. It caused errors when
running tests.
* Made title names more consistent across templates.
* Added database configuration to conftest.py
* Removed register_blueprints helper and added blueprints using the
app.register_blueprint command. I think this gives a clearer view (no
pun intended) of what routes exist on the app at a glance.
* Changed Makefile to get Database name from env var or default value.
* Added pytest-postgresql to requirements.txt
* Added tests for each view to make sure the title is displayed. This
was to help in making sure blueprints were registered correctly.
* Removed url_prefix from each blueprint b/c it is defined in the
factory function now.