### PR TITLE
Fix config default DB_NAME to qualitas_db

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,6 +6,8 @@ services:
     ports:
       - "5001:5000"
     env_file: .env
+    environment:
+      DB_HOST: db
     command: flask run --host=0.0.0.0 --port=5000
   db:
     image: postgres:10.5-alpine

--- a/instance/conf.py
+++ b/instance/conf.py
@@ -9,7 +9,20 @@ from qualitas.utils import make_database_url
 # MAIN FLASK APPLICATION
 DEBUG = os.environ.get('FLASK_DEBUG', False)
 SECRET_KEY = os.environ.get('SESSION_SECRET', str(uuid.uuid4()))
-SQLALCHEMY_DATABASE_URI = make_database_url()
+DB_USER = os.environ.get('DB_USER', 'postgres')
+DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
+DB_HOST = os.environ.get('DB_HOST', '127.0.0.1')
+DB_PORT = os.environ.get('DB_PORT', '5432')
+DB_NAME = os.environ.get('DB_NAME', 'qualitas_db')
+DB_URL = os.environ.get('DB_URL')
+SQLALCHEMY_DATABASE_URI = make_database_url(
+    DB_USER=DB_USER,
+    DB_PASSWORD=DB_PASSWORD,
+    DB_HOST=DB_HOST,
+    DB_PORT=DB_PORT,
+    DB_NAME=DB_NAME,
+    DB_URL=DB_URL,
+)
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SERVER_NAME = os.environ.get('FLASK_SERVER_NAME', None)
 PREFERRED_URL_SCHEME = os.environ.get('FLASK_PREFERRED_URL_SCHEME', 'http')

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -14,7 +14,7 @@ sys.path.insert(1, os.path.join(os.getcwd(), 'website'))
 
 from qualitas import create_app
 from qualitas.factory import db
-from qualitas.utils import make_database_url
+from instance import conf
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -36,7 +36,7 @@ target_metadata = db.metadata
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
-url = make_database_url()
+url = conf.SQLALCHEMY_DATABASE_URI
 
 
 def run_migrations_offline():

--- a/qualitas/utils.py
+++ b/qualitas/utils.py
@@ -13,17 +13,19 @@ from inflection import parameterize
 from werkzeug.routing import BaseConverter
 
 
-def make_database_url():
+def make_database_url(**environ):
+    if not environ:
+        environ = os.environ
     # Check for DATABASE_URL that is provided by heroku
-    if 'DATABASE_URL' in os.environ and os.environ['DATABASE_URL']:
-        return os.environ.get('DATABASE_URL')
+    if 'DATABASE_URL' in environ and environ['DATABASE_URL']:
+        return environ.get('DATABASE_URL')
     else:
         return 'postgresql+psycopg2://{0}:{1}@{2}:{3}/{4}'.format(
-            os.environ.get('DB_USER', 'postgres'),
-            os.environ.get('DB_PASSWORD', ''),
-            os.environ.get('DB_HOST', '127.0.0.1'),
-            os.environ.get('DB_PORT', '5432'),
-            os.environ.get('DB_NAME', 'tests'),
+            environ.get('DB_USER', 'postgres'),
+            environ.get('DB_PASSWORD', ''),
+            environ.get('DB_HOST', '127.0.0.1'),
+            environ.get('DB_PORT', '5432'),
+            environ.get('DB_NAME', 'tests'),
         )
 
 


### PR DESCRIPTION
- Set DB_HOST to db in docker-compose.override.yml

  By default, DB_HOST is localhost, which doesn't work when you use the
  docker compose override file because it's in another container called
  "db".  Set `DB_HOST` to "db".

- Fix config default DB_NAME to qualitas_db

  When running `make initdb`:
  
  ```
  ...
  docker-compose exec web alembic upgrade head
  Traceback (most recent call last):
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 2262, in _wrap_pool_connect
      return fn()
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 303, in unique_connection
      return _ConnectionFairy._checkout(self)
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 760, in _checkout
      fairy = _ConnectionRecord.checkout(pool)
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 492, in checkout
      rec = pool._do_get()
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/impl.py", line 139, in _do_get
      self._dec_overflow()
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py", line 68, in __exit__
      compat.reraise(exc_type, exc_value, exc_tb)
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 129, in reraise
      raise value
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/impl.py", line 136, in _do_get
      return self._create_connection()
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 308, in _create_connection
      return _ConnectionRecord(self)
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 437, in __init__
      self.__connect(first_connect_check=True)
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/pool/base.py", line 639, in __connect
      connection = pool._invoke_creator(self)
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/strategies.py", line 114, in connect
      return dialect.connect(*cargs, **cparams)
    File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 453, in connect
      return self.dbapi.connect(*cargs, **cparams)
    File "/usr/local/lib/python3.7/site-packages/psycopg2/__init__.py", line 130, in connect
      conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
  psycopg2.OperationalError: FATAL:  database "tests" does not exist
  ```
  
  This is fixed by setting the default for DB_NAME to qualitas_db.
