### PR TITLE
keep cnx-repos table header visible

### DIFF
--- a/qualitas/static/css/style.css
+++ b/qualitas/static/css/style.css
@@ -6,3 +6,10 @@ fieldset {
 strong {
     font-weight: 800;
 }
+
+thead {
+    /* cnx-repos table is long so keep the header visible */
+    top: 0;
+    position: sticky;
+    background-color: white;
+}


### PR DESCRIPTION
![Kapture 2019-07-16 at 8 12 26](https://user-images.githubusercontent.com/253202/61297270-808fed00-a7a1-11e9-9090-d7993a323661.gif)
