### PR TITLE
fix sticky table header in Chrome

### DIFF
--- a/qualitas/static/css/style.css
+++ b/qualitas/static/css/style.css
@@ -7,7 +7,7 @@ strong {
     font-weight: 800;
 }
 
-thead {
+thead th {
     /* cnx-repos table is long so keep the header visible */
     top: 0;
     position: sticky;


### PR DESCRIPTION

![Kapture 2019-07-16 at 8 12 26](https://user-images.githubusercontent.com/253202/61297270-808fed00-a7a1-11e9-9090-d7993a323661.gif)

Chrome does not allow `position: sticky;` on `<thead>` elements, only individual `th` cells.

See https://stackoverflow.com/questions/15646747/why-doesnt-position-sticky-work-in-chrome#comment22204998_15646803 and https://stackoverflow.com/a/44004100